### PR TITLE
Allow service_url to be determined from ctx

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const cas = new Cas({
 | Name | Type | Description | Default |
 |:-----|:----:|:------------|:-------:|
 | cas_url | _string_ | The URL of the CAS server. | _(required)_ |
-| service_url | _string_ | The URL of the application which is registered with the CAS server as a valid service. | _(required)_ |
+| service_url | _string\|function_ | The URL of the application which is registered with the CAS server as a valid service. This can also be a function accepts `ctx` and returns the service URL. | _(required)_ |
 | cas_version | _"1.0"\|"2.0\|"3.0"\|"saml1.1"_ | The CAS protocol version. | _"3.0"_ |
 | renew | _boolean_ | If true, an unauthenticated client will be required to login to the CAS system regardless of whether a single sign-on session exists. | _false_ |
 | is_dev_mode | _boolean_ | If true, no CAS authentication will be used and the session CAS variable will be set to whatever user is specified as _dev_mode_user_. | _false_ |

--- a/index.js
+++ b/index.js
@@ -192,6 +192,17 @@ module.exports = class Cas {
   }
 
   /**
+   * Get the application's service url. It may depend on the current HTTP
+   * request if the service_url argument is a function.
+   * @private
+   */
+  _get_service_url(ctx) {
+    return typeof this.service_url === 'function'
+      ? this.service_url(ctx)
+      : this.service_url
+  }
+
+  /**
    * Bounces a request with CAS authentication. If the user's session is not
    * already validated with CAS, their request will be redirected to the CAS
    * login page.
@@ -290,7 +301,7 @@ function _login(ctx, next) {
 
   // Set up the query parameters.
   var query = {
-    service: this.service_url + url.parse(ctx.url).pathname,
+    service: this._get_service_url(ctx) + url.parse(ctx.url).pathname,
     renew: this.renew
   }
 
@@ -346,7 +357,7 @@ async function _handleTicket(ctx, next) {
     requestOptions.path = url.format({
       pathname: this.cas_path + _validateUri,
       query: {
-        service: this.service_url + url.parse(ctx.url).pathname,
+        service: this._get_service_url(ctx) + url.parse(ctx.url).pathname,
         ticket: ctx.query.ticket
       }
     })
@@ -370,7 +381,7 @@ async function _handleTicket(ctx, next) {
     requestOptions.path = url.format({
       pathname: this.cas_path + _validateUri,
       query: {
-        TARGET: this.service_url + url.parse(ctx.url).pathname,
+        TARGET: this._get_service_url(ctx) + url.parse(ctx.url).pathname,
         ticket: ''
       }
     })


### PR DESCRIPTION
This is a fantastic library. I'd like to propose a small change for my use cases. Depending on several factors, the `service_url` of my application can be different. It can be:

1. The production domain
2. `localhost:3000` if I'm running in development
3. `localhost:8080` if I'm proxying through the webpack dev server
4. `localhost:8081` if port `8080` is used and the webpack dev server automatically selects the next highest port

I can handle this through an environment variable, but I'd really like to determine the service_url from the HTTP request. Plus the environment variable adds an extra step to application setup which I try to minimize.

I think a simple change to the `service_url` parameter allowing it to accept a function would allow this functionality and others. For myself, I would simply set it to `ctx => ctx.protocol + '://' + ctx.host`.

Thanks!